### PR TITLE
cmake refactored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,47 @@ set(PROJECT_NAME
 
 project(${PROJECT_NAME})
 
-
 set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -std=c++11")
+
+
+if (NOT MONERO_DIR)
+    set(MONERO_DIR ~/monero)
+endif()
+
+message(STATUS MONERO_DIR ": ${MONERO_DIR}")
+
+set(MONERO_SOURCE_DIR ${MONERO_DIR}
+        CACHE PATH "Path to the root directory for Monero")
+
+# set location of monero build tree
+set(MONERO_BUILD_DIR ${MONERO_SOURCE_DIR}/build/release/
+        CACHE PATH "Path to the build directory for Monero")
+
+set(MY_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}/cmake"
+        CACHE PATH "The path to the cmake directory of the current project")
+
+list(APPEND CMAKE_MODULE_PATH "${MY_CMAKE_DIR}")
+
+set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${MONERO_BUILD_DIR}"
+        CACHE PATH "Add Monero directory for library searching")
+
+include(MyUtils)
+
+find_package(Monero)
+
+include_directories(/usr/include/mysql)
+
+# include boost headers
+include_directories(${Boost_INCLUDE_DIRS})
+
+# include monero headers
+include_directories("ext/restbed/source")
+
+
+create_git_version()
+
+configure_files(${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_CURRENT_BINARY_DIR}/config)
 
 # find boost
 find_package(Boost COMPONENTS
@@ -21,140 +59,6 @@ find_package(Boost COMPONENTS
         program_options
         date_time
         REQUIRED)
-
-
-# set location of monero static libraries
-set(MONERO_LIBS_DIR
-        /opt/monero-dev/libs)
-
-# set location of moneroheaders
-set(MONERO_HEADERS_DIR
-        /opt/monero-dev/headers)
-
-# include monero headers
-include_directories(
-        ${MONERO_HEADERS_DIR}/src
-        ${MONERO_HEADERS_DIR}/external
-        ${MONERO_HEADERS_DIR}/build
-        ${MONERO_HEADERS_DIR}/external/easylogging++
-        ${MONERO_HEADERS_DIR}/contrib/epee/include
-        ${MONERO_HEADERS_DIR}/external/db_drivers/liblmdb)
-
-include_directories(/usr/include/mysql)
-
-# get individual monero static libraries
-# that are needed in this project
-
-
-add_library(common STATIC IMPORTED)
-set_property(TARGET common PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libcommon.a)
-
-add_library(blocks STATIC IMPORTED)
-set_property(TARGET blocks PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libblocks.a)
-
-add_library(cryptoxmr STATIC IMPORTED)
-set_property(TARGET cryptoxmr
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libcrypto.a)
-
-add_library(cryptonote_basic STATIC IMPORTED)
-set_property(TARGET cryptonote_basic
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libcryptonote_basic.a)
-
-add_library(cryptonote_core STATIC IMPORTED)
-set_property(TARGET cryptonote_core
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libcryptonote_core.a)
-
-add_library(cryptonote_protocol STATIC IMPORTED)
-set_property(TARGET cryptonote_protocol
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libcryptonote_protocol.a)
-
-add_library(daemonizer STATIC IMPORTED)
-set_property(TARGET daemonizer
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libdaemonizer.a)
-
-add_library(mnemonics STATIC IMPORTED)
-set_property(TARGET mnemonics
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libmnemonics.a)
-
-add_library(epee STATIC IMPORTED)
-set_property(TARGET epee
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libepee.a)
-
-add_library(blockchain_db STATIC IMPORTED)
-set_property(TARGET blockchain_db
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libblockchain_db.a)
-
-add_library(lmdb STATIC IMPORTED)
-set_property(TARGET lmdb
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/liblmdb.a)
-
-add_library(ringct STATIC IMPORTED)
-set_property(TARGET ringct
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libringct.a)
-
-add_library(wallet STATIC IMPORTED)
-set_property(TARGET wallet
-        PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libwallet.a)
-
-# include boost headers
-include_directories(${Boost_INCLUDE_DIRS})
-
-# include monero headers
-include_directories(
-        "ext/restbed/source")
-
-
-
-# Get the current working branch
-execute_process(
-        COMMAND git rev-parse --abbrev-ref HEAD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_BRANCH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# http://xit0.org/2013/04/cmake-use-git-branch-and-commit-details-in-project/
-# Get the latest abbreviated commit hash of the working branch
-execute_process(
-        COMMAND git log -1 --format=%h
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_COMMIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Get the date and time of last commit
-execute_process(
-        COMMAND git log -1 --format=%cd --date=short
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_COMMIT_DATETIME
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-configure_file(
-        ${CMAKE_SOURCE_DIR}/src/version.h.in
-        ${CMAKE_BINARY_DIR}/gen/version.h
-)
-
-include_directories(${CMAKE_BINARY_DIR}/gen)
-
-macro(configure_files srcDir destDir)
-    message(STATUS "Configuring directory ${destDir}")
-    make_directory(${destDir})
-
-    file(GLOB templateFiles RELATIVE ${srcDir} ${srcDir}/*)
-    foreach(templateFile ${templateFiles})
-        set(srcTemplatePath ${srcDir}/${templateFile})
-        if(NOT IS_DIRECTORY ${srcTemplatePath})
-            message(STATUS "Configuring file ${templateFile}")
-            configure_file(
-                    ${srcTemplatePath}
-                    ${destDir}/${templateFile}
-                    @ONLY)
-        endif(NOT IS_DIRECTORY ${srcTemplatePath})
-    endforeach(templateFile)
-endmacro(configure_files)
-
-configure_files(${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_CURRENT_BINARY_DIR}/config)
 
 
 # add src/ subfolder
@@ -187,6 +91,7 @@ target_link_libraries(${PROJECT_NAME}
         common
         mnemonics
         epee
+        easylogging
         mysqlpp
         mysqlclient
         ${Boost_LIBRARIES}

--- a/README.md
+++ b/README.md
@@ -81,21 +81,39 @@ Open Monero is not as fast as MyMonero. This is because it is basic, easy to und
 Below are example and basic instructions on how to setup up and run Open Monero on Ubuntu 16.04. 
 
 
-#### Monero libraries
+#### Monero download and compilation
 
-Monero's libraries and header files are setup is described here:
+Download and compile Monero into your home folder:
 
-- [compile-monero-on-ubuntu-16-04](https://github.com/moneroexamples/compile-monero-09-on-ubuntu-16-04)
+```bash
+# first install monero dependecines
+sudo apt update
+
+sudo apt install git build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libcurl4-openssl-dev libgtest-dev
+
+# go to home folder 
+cd ~
+
+git clone https://github.com/monero-project/monero
+
+cd monero/
+
+make
+```
 
 #### Compilation of the Open Monero (don't run it yet)
 
-Download Open Monero and compile it. In fact we could postpone compilation to later, but 
+Once Monero was downloaed and compiled, we can download Open Monero and compile it. 
+In fact we could postpone compilation to later, but 
 we can just do it now, to see if it compiles. But don't run it yet. It will not
 work without database, setup frontend, and synced and running monero blockchain.
 
 ```bash
 # need mysql++ libraries 
-sudo apt install libmysql++-dev 
+sudo apt install libmysql++-dev
+ 
+# go to home folder if still in ~/monero
+cd ~
 
 git clone https://github.com/moneroexamples/openmonero.git
 
@@ -104,6 +122,9 @@ cd openmonero
 mkdir build && cd build
 
 cmake ..
+
+# altearnatively can use cmake -DMONERO_DIR=/path/to/monero_folder .. 
+# if monero is not in ~/monero
 
 make
 ```

--- a/cmake/FindMonero.cmake
+++ b/cmake/FindMonero.cmake
@@ -1,0 +1,85 @@
+#------------------------------------------------------------------------------
+# CMake helper for the majority of the cpp-ethereum modules.
+#
+# This module defines
+#     Monero_XXX_LIBRARIES, the libraries needed to use ethereum.
+#     Monero_FOUND, If false, do not try to use ethereum.
+#
+# File addetped from cpp-ethereum
+#
+# The documentation for cpp-ethereum is hosted at http://cpp-ethereum.org
+#
+# ------------------------------------------------------------------------------
+# This file is part of cpp-ethereum.
+#
+# cpp-ethereum is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cpp-ethereum is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2014-2016 cpp-ethereum contributors.
+#------------------------------------------------------------------------------
+
+set(LIBS common;blocks;cryptonote_basic;cryptonote_core;
+		cryptonote_protocol;daemonizer;mnemonics;epee;lmdb;
+		blockchain_db;ringct;wallet)
+
+set(Xmr_INCLUDE_DIRS "${CPP_MONERO_DIR}")
+
+# if the project is a subset of main cpp-ethereum project
+# use same pattern for variables as Boost uses
+
+foreach (l ${LIBS})
+
+	string(TOUPPER ${l} L)
+
+	find_library(Xmr_${L}_LIBRARY
+		NAMES ${l}
+		PATHS ${CMAKE_LIBRARY_PATH}
+		PATH_SUFFIXES "/src/${l}" "/external/db_drivers/lib${l}" "/lib" "/src/crypto" "/contrib/epee/src"
+		NO_DEFAULT_PATH
+	)
+
+	set(Xmr_${L}_LIBRARIES ${Xmr_${L}_LIBRARY})
+
+	message(STATUS FindMonero " Xmr_${L}_LIBRARIES ${Xmr_${L}_LIBRARY}")
+
+	add_library(${l} STATIC IMPORTED)
+	set_property(TARGET ${l} PROPERTY IMPORTED_LOCATION ${Xmr_${L}_LIBRARIES})
+
+endforeach()
+
+
+if (EXISTS ${MONERO_BUILD_DIR}/external/unbound/libunbound.a)
+	add_library(unbound STATIC IMPORTED)
+	set_property(TARGET unbound PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/external/unbound/libunbound.a)
+endif()
+
+if (EXISTS ${MONERO_BUILD_DIR}/src/crypto/libcrypto.a)
+	add_library(cryptoxmr STATIC IMPORTED)
+	set_property(TARGET cryptoxmr
+			PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/src/crypto/libcrypto.a)
+endif()
+
+if (EXISTS ${MONERO_BUILD_DIR}/external/easylogging++/libeasylogging.a)
+	add_library(easylogging STATIC IMPORTED)
+	set_property(TARGET easylogging
+			PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/external/easylogging++/libeasylogging.a)
+endif()
+
+# include monero headers
+include_directories(
+		${MONERO_SOURCE_DIR}/src
+		${MONERO_SOURCE_DIR}/external
+		${MONERO_SOURCE_DIR}/build
+		${MONERO_SOURCE_DIR}/external/easylogging++
+		${MONERO_SOURCE_DIR}/contrib/epee/include
+		${MONERO_SOURCE_DIR}/external/db_drivers/liblmdb)

--- a/cmake/MyUtils.cmake
+++ b/cmake/MyUtils.cmake
@@ -1,0 +1,52 @@
+
+macro(configure_files srcDir destDir)
+    message(STATUS "Configuring directory ${destDir}")
+    make_directory(${destDir})
+
+    file(GLOB templateFiles RELATIVE ${srcDir} ${srcDir}/*)
+    foreach(templateFile ${templateFiles})
+        set(srcTemplatePath ${srcDir}/${templateFile})
+        if(NOT IS_DIRECTORY ${srcTemplatePath})
+            message(STATUS "Configuring file ${templateFile}")
+            configure_file(
+                    ${srcTemplatePath}
+                    ${destDir}/${templateFile}
+                    @ONLY)
+        endif(NOT IS_DIRECTORY ${srcTemplatePath})
+    endforeach(templateFile)
+endmacro(configure_files)
+
+macro(create_git_version)
+    # Get the current working branch
+    execute_process(
+            COMMAND git rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # http://xit0.org/2013/04/cmake-use-git-branch-and-commit-details-in-project/
+    # Get the latest abbreviated commit hash of the working branch
+    execute_process(
+            COMMAND git log -1 --format=%h
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_COMMIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Get the date and time of last commit
+    execute_process(
+            COMMAND git log -1 --format=%cd --date=short
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_COMMIT_DATETIME
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    configure_file(
+            ${CMAKE_SOURCE_DIR}/src/version.h.in
+            ${CMAKE_BINARY_DIR}/gen/version.h
+    )
+
+    include_directories(${CMAKE_BINARY_DIR}/gen)
+
+endmacro(create_git_version)

--- a/cmake/ProjectMonero.cmake
+++ b/cmake/ProjectMonero.cmake
@@ -1,0 +1,13 @@
+include(ExternalProject)
+include(GNUInstallDirs)
+
+
+ExternalProject_Add(monero
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    DOWNLOAD_NO_PROGRESS 0
+    URL https://github.com/monero-project/monero/archive/v0.10.3.1.tar.gz
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND make
+    LOG_BUILD 1
+    INSTALL_COMMAND ""
+)


### PR DESCRIPTION
Modification was made so that setting up Monero headers and libraries files in `/opt/monero-dev` is not needed anymore. 

Thanks to suggestions from @hyc

