### PR TITLE
restbed: add default close header

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -194,6 +194,7 @@ if (config_json["ssl"]["enable"])
 else
 {
     settings->set_port(app_port);
+    settings->set_default_header( "Connection", "close" );
 
     cout << "Start the service at http://localhost:" << app_port  << endl;
 }


### PR DESCRIPTION
GUI/CLI only closes the socket if response header contains "Connection: close". 
https://github.com/monero-project/monero/blob/master/contrib/epee/include/net/http_client.h#L480

This results in a block of all subsequent requests after the first RPC call is made. If web wallet isn't dependent on keep-alive requests, I'd suggest this change instead of hacking monero's http_client. 

Note that I haven't tested this patch yet. :)