### PR TITLE
fix for 32-bit build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(${PROJECT_NAME})
 set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -std=c++11")
 
+if(CMAKE_SIZEOF_VOID_P EQUAL "4")
+  add_definitions(-DMDB_VL32)
+endif()
 
 if (NOT MONERO_DIR)
     set(MONERO_DIR ~/monero)

--- a/ext/lmdb++.h
+++ b/ext/lmdb++.h
@@ -812,7 +812,7 @@ namespace lmdb {
   static inline bool cursor_get(MDB_cursor* cursor, MDB_val* key, MDB_val* data, MDB_cursor_op op);
   static inline void cursor_put(MDB_cursor* cursor, MDB_val* key, MDB_val* data, unsigned int flags);
   static inline void cursor_del(MDB_cursor* cursor, unsigned int flags);
-  static inline void cursor_count(MDB_cursor* cursor, std::size_t& count);
+  static inline void cursor_count(MDB_cursor* cursor, mdb_size_t& count);
 }
 
 /**
@@ -916,7 +916,7 @@ lmdb::cursor_del(MDB_cursor* const cursor,
  */
 static inline void
 lmdb::cursor_count(MDB_cursor* const cursor,
-                   std::size_t& count) {
+                   mdb_size_t& count) {
   const int rc = ::mdb_cursor_count(cursor, &count);
   if (rc != MDB_SUCCESS) {
     error::raise("mdb_cursor_count", rc);


### PR DESCRIPTION
This fixes a linker error with undefined reference to `mdb_env_create` which gets a different symbol when built for 32-bit systems.