### PR TITLE
Add build command to restbed cmake file so linker picks it up

### DIFF
--- a/cmake/FindRestbed.cmake
+++ b/cmake/FindRestbed.cmake
@@ -25,7 +25,7 @@ if ( restbed_SOURCE )
     message( STATUS "${Green}Found Restbed include at: 
     ${restbed_SOURCE}${Reset}" )
 
-    
+    mark_as_advanced(restbed_INCLUDE restbed_LIBRARY)
 
     #add_library(Restbed::Restbed INTERFACE IMPORTED GLOBAL)
 


### PR DESCRIPTION
Seems the `mark_as_advanced` command was necessary for the linker to pick up restbed

Addresses #172 